### PR TITLE
Parameterize eds container demands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.2.7 / 2022-06-15
+
+- Parameterize EDS Azure Pipeline container demands
+
 ## 1.2.6 / 2022-06-08
 
 - Update community calls to reflect changes to library

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 1.2.6
+**Version:** 1.2.7
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-waveform-java?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2629&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
 
 parameters:
   - name: containerDemandsEDS
-    default: 1 -equals 1
+    default: Agent.OS
 
 jobs:
   - job: Tests_ADH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,10 @@ variables:
   - name: analysisProject
     value: SDS_Java
 
+parameters:
+  - name: containerDemandsEDS
+    default: 1 -equals 1
+
 jobs:
   - job: Tests_ADH
     strategy:
@@ -84,6 +88,7 @@ jobs:
   - job: Tests_EDS
     pool:
       name: 00-OSIManaged-Build
+      demands: ${{ parameters.containerDemandsEDS }}
     variables:
       - name: TenantId
         value: default

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.osisoft.sdsjava</groupId>
   <artifactId>sdsjava</artifactId>
-  <version>1.2.6</version>
+  <version>1.2.7</version>
   <name>sdsjava</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>


### PR DESCRIPTION
This is to parameterize the pipeline container demands, but there are two things of note:

1. The ADH container demands are built off of a matrix with multiple operating system demands, one per job. This will be left as is and not parameterized.
2. The EDS container can be run on any container and has no demands. In order to have a parameter, the default value needs to always be true, and therefore the default value is set to Agent.OS. This checks the existence of an operating system on the Agent, which will always be true, while still exposing the demand to a parameter that can be set when we need to be more precise.